### PR TITLE
Read environment file in systemd service, use atop defaults

### DIFF
--- a/atop.service
+++ b/atop.service
@@ -3,8 +3,15 @@ Description=Atop advanced performance monitor
 Documentation=man:atop(1)
 
 [Service]
-ExecStart=/bin/sh -c 'exec /usr/bin/atop -w /var/log/atop/atop_`date +%%Y%%m%%d` 60'
-ExecStartPost=/usr/bin/find /var/log/atop -name "atop_*" -mtime +28 -exec rm -v {} \;
+Environment=LOGOPTS="-R"
+Environment=LOGINTERVAL=600
+Environment=LOGGENERATIONS=28
+Environment=LOGPATH=/var/log/atop
+EnvironmentFile=/etc/default/atop
+ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTERVAL"'
+ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
+ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL} > "${LOGPATH}/daily.log"'
+ExecStartPost=/usr/bin/find "${LOGPATH}" -name "atop_*" -mtime +${LOGGENERATIONS} -exec rm -v {} \;
 
 [Install]
 WantedBy=multi-user.target

--- a/atop.service
+++ b/atop.service
@@ -9,7 +9,7 @@ Environment=LOGGENERATIONS=28
 Environment=LOGPATH=/var/log/atop
 EnvironmentFile=/etc/default/atop
 ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTERVAL"'
-ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
+ExecStartPre=/bin/sh -c 'test -n "$LOGGENERATIONS" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
 ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL}'
 ExecStartPost=/usr/bin/find "${LOGPATH}" -name "atop_*" -mtime +${LOGGENERATIONS} -exec rm -v {} \;
 

--- a/atop.service
+++ b/atop.service
@@ -10,7 +10,7 @@ Environment=LOGPATH=/var/log/atop
 EnvironmentFile=/etc/default/atop
 ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTERVAL"'
 ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
-ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL} > "${LOGPATH}/daily.log"'
+ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL}'
 ExecStartPost=/usr/bin/find "${LOGPATH}" -name "atop_*" -mtime +${LOGGENERATIONS} -exec rm -v {} \;
 
 [Install]


### PR DESCRIPTION
This change makes sure the systemd file uses the `/etc/default/atop` environment file to resemble [atop.daily](https://github.com/Atoptool/atop/blob/master/atop.daily#L10). Additionally you changed the default interval from 10 to 1 minutes, I adjusted that as well.