### PR TITLE
Set systemd kill signal to SIGUSR2

### DIFF
--- a/atop.service
+++ b/atop.service
@@ -12,6 +12,7 @@ ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTER
 ExecStartPre=/bin/sh -c 'test -n "$LOGGENERATIONS" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
 ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL}'
 ExecStartPost=/usr/bin/find "${LOGPATH}" -name "atop_*" -mtime +${LOGGENERATIONS} -exec rm -v {} \;
+KillSignal=SIGUSR2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This tells systemd to stop atop by sending SIGUSR2. The SIGUSR2 signal forces atop to write another sample to the logfile and terminate, which is relevant for using it with the systemd timer.

Note that systemd will still send a FinalKillSignal (SIGKILL) after a timeout (90s default).